### PR TITLE
Officially finished with minion movement - added millipede formation

### DIFF
--- a/src/enemies.js
+++ b/src/enemies.js
@@ -132,7 +132,6 @@ class Cthulhu extends Enemy {
         const height = 245;
         super(game, x, y, width, height, scale);
 
-        // TODO - May update to include more animations later on depending on damage received, attack moves, etc.
         // Default floating animation.
         this.sprite = ASSET_MANAGER.getAsset("./res/cthulhuSprite.png");
         this.animations.push(new Animator(this.sprite, 0, 0, this.width, this.height, 10, 0.3,
@@ -140,9 +139,22 @@ class Cthulhu extends Enemy {
 
         // Functionality to control the spawning of minions.
         this.minion_count = 0;
-        this.startTimer = Math.floor(Date.now()/1000);
-        this.oldTime = 0;
+        this.spawnFrequency = 1;
+        this.spawnMax = 50;
+
+        // Controls spawning of millipede.
+        this.xMinionPosition = this.x;
+        this.spawnMillipede = false;
+        this.millipedeCounter = 0;
+        this.resetCount = false;
+        this.restoreCount = 0;
+
+        // Life of enemy
         this.life = 20000;
+        this.totalLife = this.life;
+
+        this.startTimer = Math.floor(Date.now()/100);
+        this.oldTime = 0;
     };
 
     /**
@@ -150,6 +162,11 @@ class Cthulhu extends Enemy {
      * the Cthulhu minion.
      */
     update() {
+        // Timer that determines spawning intervals.
+        this.endTimer = Math.floor(Date.now()/100);
+        this.elapsedTime = this.endTimer - this.startTimer; // elapsed time in centiseconds.
+
+        // Default movement.
         if (this.x <= this.startX + 125 && this.goRight) {
             this.x++;
         } else {
@@ -164,20 +181,75 @@ class Cthulhu extends Enemy {
         }
 
 
-        // Functionality to control the spawning of minions.
-        this.endTimer = Math.floor(Date.now()/1000);
-        this.elapsedTime = this.endTimer - this.startTimer;
-        // Spawn the minion.
-        this.spawnMinion(this.x, this.y , 3, 15);
+        // Controls regular minion spawn behavior. Dependent on Cthulhu life remaining.
+        if (this.life >= this.totalLife * 3/4) { // Life greater than a quarter of original life.
+            this.spawnFrequency = 5; // 1 minion every 50 centiseconds
+            this.spawnMax = 150;
+        } else if (this.life >= this.totalLife * 1/2) { // Life less then Quarter but greater than 1/2 of original life.
+            this.spawnFrequency = 2; // 1 minion every 25 milliseconds
+            this.spawnMax = 300;
+        } else if (this.life >= this.totalLife * 1/4) {
+            this.spawnFrequency = 1; // 1 minion every 10 milliseconds
+            this.spawnMax = 1000;
+        } else if (this.life >= this.totalLife * 1/8) { // Life very low - go crazy.
+            this.spawnFrequency = 1; // Ultimate -  1 minion every millisecond
+            this.spawnMax = 100000; // Ultimate
+        }
+
+        // Randomize x-coordinate for minion.
+        this.xMinionPosition = Math.floor((Math.random() * PARAMS.CANVAS_WIDTH - 96) + 96);
+
+        this.spawnMillipedeCreature(250, 1);
+        this.spawnMinion(this.xMinionPosition,  - 100, this.spawnFrequency, this.spawnMax);
+
         super.updateBB();
         super.checkCollision(this.game.entities);
     };
 
+    /**
+     * Determines when to spawn the minion millipede formation. When it is time to spawn the millipede the regular
+     * minion spawning halts until the full length of the millipede is spawned. Once millipede is spawned regular minion
+     * spawning resumes at original rate pre-spawn.
+     *
+     * @param millipedeLength int value that determines how many minions make up a millipede.
+     * @param distanceBetween int centisecond value that determines how closely each minion is spawned to the following one.
+     */
+    spawnMillipedeCreature(millipedeLength, distanceBetween) {
+        // The frequency of the millipede is dependent on the length of millipede.
+        let millipedeFrequency = 2 * millipedeLength + (millipedeLength/2)
+        if (this.elapsedTime % millipedeFrequency === 0 && this.oldTime > 0) {
+            this.spawnMillipede = true;
+            this.resetCount = true;
+        }
+
+        // Control length of millipede & how close minions spawn together.
+        if (this.spawnMillipede) {
+            this.xMinionPosition = this.x; // Millipede dependent on Cthulhu position.
+            this.spawnFrequency = distanceBetween; // How close each minion spawns to the next one.
+            this.spawnMax = millipedeLength;  // Length of the millipede.
+
+            //  Reset and save minion count prior to millipede spawn.
+            if (this.resetCount) {
+                this.resetCount = false;
+                this.restoreCount = this.minion_count;
+                this.minion_count = 0;
+            }
+        }
+
+        // Stop spawning millipede at the max millipede length.
+        if (this.millipedeCounter >= millipedeLength) {
+            this.spawnMillipede = false;
+            this.millipedeCounter = 0;
+            this.minion_count = this.restoreCount; // restore original minion count prior to millipede.
+        }
+
+    }
+
 
     /**
      * Controls the spawning of spawning of minions. spawnFrequency controls how quickly minions are spawned. It is
-     * based on timer in seconds (e.g. spawnTime = 1, 1 minion spawned every second. spawnTime = 10, 1 minion spawned
-     * every 10 seconds).
+     * based on timer in seconds (e.g. spawnTime = 1000 ms, 1 minion spawned every second. spawnTime = 10, 1 minion spawned
+     * every 10 milliseconds).
      *
      * @param xStart starting spawn x coordinate
      * @param yStart starting spawn y coordinate
@@ -188,7 +260,10 @@ class Cthulhu extends Enemy {
         if (this.minion_count < spawnMax) {
             if (this.elapsedTime % spawnFrequency === 0 && this.elapsedTime !== this.oldTime) {
                 this.spawn(xStart, yStart)
-                this.oldTime = this.elapsedTime; // Keep track of old time (to ensure seconds)
+                this.oldTime = this.elapsedTime; // Keep track of old time (to ensure correct count of centiseconds)
+                if (this.spawnMillipede) {
+                    this.millipedeCounter++;
+                }
             }
         }
     };
@@ -204,7 +279,7 @@ class Cthulhu extends Enemy {
    };
 
     /**
-     * Chutulu draw method. Single default animation.
+     * Cthulhu draw method. Single default animation.
      * @param ctx context.
      */
     draw(ctx) {
@@ -308,6 +383,7 @@ class FingerGunDude extends Enemy {
     }
 }
 
+
 /**
  * Cthulhu Minion that has two different default animations: Float & Attack. Movement is automatic based on a time
  * interval. Spawning of this character is controlled by the Cthulhu class.
@@ -336,16 +412,17 @@ class CthulhuMinion extends Enemy {
 
         this.life = 50;
 
+        this.startTimer = Date.now();
         this.loadAnimations();
         super.updateBB();
-    };
+    }
 
     loadAnimations() {
         this.animations.push(new Animator(this.spriteFloat, 0, 0, this.width, this.height, 5, 0.2,
             0, false, true));
         this.animations.push(new Animator(this.spriteAttack, 0, 0, this.width, this.height, 6, 0.2,
             0, false, true));
-    };
+    }
 
     update() {
 
@@ -365,7 +442,7 @@ class CthulhuMinion extends Enemy {
         this.velocity.x = 0;
         this.velocity.y = 0;
 
-        // SPRITE MOVING LEFT ( and or UP/DOWN)
+        // SPRITE MOVING LEFT ( and/or UP/DOWN)
         if (this.velocity.x <= 0 && this.direction === Direction.LEFT) { // moving left
             if (this.BB.left < 0) { // check if we need to reverse
                 this.direction = Direction.RIGHT; // Switch directions and go right.
@@ -380,7 +457,7 @@ class CthulhuMinion extends Enemy {
             }
         }
 
-        // SPRITE MOVING RIGHT ( and or UP/DOWN)
+        // SPRITE MOVING RIGHT ( and/or UP/DOWN)
         else if (this.velocity.x >= 0 && this.direction === Direction.RIGHT) { // moving right
             if (this.BB.right > PARAMS.CANVAS_WIDTH) { // check if we have gone off the right side of canvas
                 this.direction = Direction.LEFT; // go left
@@ -389,31 +466,67 @@ class CthulhuMinion extends Enemy {
                 // x axis movement.
                 this.velocity.x += this.moveFunction(VELOCITY.REGULAR, Movement.RIGHT);
                 // y axis movement.
-                let amplitude = 200;
+                let amplitude = 100;
                 let angularFrequency = 1/60;
                 this.velocity.y += amplitude * this.moveFunction(angularFrequency * (this.moveTimer++), Movement.SIN);
             }
         }
 
        /*
-       Controls the behavior of the minion [400] pixels before the bottom of the canvas.
+       Controls the behavior of the minion [300] pixels before the bottom of the canvas.
        Minions will begin to slow down until they reverse.
         */
-       if (this.BB.bottom > PARAMS.CANVAS_HEIGHT - 400) {
+       if (this.BB.bottom > PARAMS.CANVAS_HEIGHT - 300) {
             this.velocity.y -= 1 ;
             this.y -= 1;
        }
 
-        // Reset movetimer arbitrarily so not to overflow.
-        if (this.moveTimer > 10000)
+       /*
+       If the minion flies too far beyond the top of the canvas reverse their velocity.
+        */
+        if (this.BB.top < -200) {
+            this.velocity.y = -this.velocity.y;
+        }
+
+        // Reset move timer so not to overflow.
+        if (this.moveTimer > 10000) {
             this.moveTimer = 1;
+        }
 
         // Update sprite position.
         this.x += this.velocity.x * TICK * this.scale;
         this.y += this.velocity.y * TICK * this.scale;
         super.updateBB();
+
+        // Bullet firing mechanism
+        this.bulletPattern(200, 250, 50);
+
+        // Collision
         super.checkCollision(this.game.entities);
-    };
+    }
+
+    /**
+     * Controls the firing mechanism for minions. There are two different firing modes based on the location
+     * of the minion along the y-coordinate. There is a regular firing pattern in which the minion will fire
+     * at the regular fireInterval rate that is specified in milliseconds. If comes within a certain distance
+     * of the bottom of the canvas then the firing interval is dependent on  fireIntervalSpecial.
+     * @param distance from the bottom of the canvas.
+     * @param fireInterval regular fire interval.
+     * @param fireIntervalSpecial fire interval when minion comes within a certain distance of the bottom of canvas.
+     */
+    bulletPattern(distance, fireInterval, fireIntervalSpecial) {
+        // Controls the firing mechanism for the minions.
+        this.endTimer = Date.now();
+        this.elapsedTime = this.startTimer - this.endTimer;
+        // Special fire interval.
+        if (this.BB.bottom > PARAMS.CANVAS_HEIGHT - distance && this.elapsedTime % fireIntervalSpecial === 0) {
+            this.game.addEntity(new CthulhuMinionBullet(this.game, this.x + this.width/2, this.y + this.height - 15, 1));
+        }
+        // Regular fire interval.
+        else if (this.elapsedTime % fireInterval === 0) {
+            this.game.addEntity(new CthulhuMinionBullet(this.game, this.x + this.width/2, this.y + this.height - 15, 1));
+        }
+    }
 
     /**
      * Controls the velocity of the sprite.
@@ -424,11 +537,11 @@ class CthulhuMinion extends Enemy {
     moveFunction(velocity, direction) {
         let movementFunctions = [-velocity, velocity, velocity*velocity, -Math.sin(velocity), Math.cos(velocity)];
         return movementFunctions[direction];
-    };
+    }
 
     draw(ctx) {
         super.draw(ctx);
         this.animations[this.animationType].drawFrame(this.game.clockTick, ctx, this.x, this.y, this.scale);
-    };
+    }
 
 }

--- a/src/projectiles.js
+++ b/src/projectiles.js
@@ -163,3 +163,27 @@ class FingerGunDudeBullet extends Bullet {
         super.update();
     }
 }
+
+class CthulhuMinionBullet extends Bullet {
+    constructor(game, x, y, scale) {
+        const width = 10;
+        const height = 30;
+        const bulletSpeed = 5;
+        const bulletType = 1;
+        super(game, x, y, scale, width, height, bulletSpeed, bulletType);
+    }
+
+    draw(ctx) {
+        ctx.fillStyle = "Red";
+        ctx.fillRect(this.x, this.y, this.width * this.scale, this.height * this.scale);
+
+        if (PARAMS.DEBUG) {
+            this.drawBB(ctx);
+        }
+    }
+
+    update() {
+        this.y += this.bulletSpeed;
+        super.update();
+    }
+}


### PR DESCRIPTION
- Large update for Cthulhu, Cthulhu minions, and movement. 
- Minion spawning is now dependent on the life remaining of the Cthulhu boss. The more the it's life decreases the more minions it spawns and at faster intervals. 
- Brand new millipede formation for minions.
-  Every minute the minions group together into a millipede formation and regular spawning stops. Regular spawning resumes when millipede has finished spawning.
- If boss is defeated then no more minions spawn.

- Some general cleanup. (Minion movement can be easily translated to other enemy classes).