### PR TITLE
Fixed loading bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <title>What The Shmup</title>
 
     <link rel="stylesheet" href="style.css">
-    <script src="src/loadFiles.js"></script>
+    <script defer src="src/loadFiles.js"></script>
 </head>
 
 <body>

--- a/src/game-objects/enemies/brain/brain.js
+++ b/src/game-objects/enemies/brain/brain.js
@@ -89,7 +89,7 @@ class Brain extends Enemy {
         }
 
         // Randomize x-coordinate for minion.
-        this.xMinionPosition = Math.floor((Math.random() * PARAMS.CANVAS_WIDTH - 96) + 96);
+        this.xMinionPosition = Math.floor((Math.random() * PARAMS.WIDTH - 96) + 96);
 
         this.spawnMinion(this.xMinionPosition, - 100, this.spawnFrequency, this.spawnMax);
     };

--- a/src/game-objects/enemies/brain/eye-minion.js
+++ b/src/game-objects/enemies/brain/eye-minion.js
@@ -63,7 +63,7 @@ class EyeMinion extends Enemy {
 
         // SPRITE MOVING RIGHT ( and/or UP/DOWN)
         else if (this.velocity.x >= 0 && this.direction === Direction.RIGHT) {
-            if (this.x + this.radius > PARAMS.CANVAS_WIDTH) {
+            if (this.x + this.radius > PARAMS.WIDTH) {
                 this.direction = Direction.LEFT;
             } else {
 

--- a/src/game-objects/enemies/brain/mouth-minion.js
+++ b/src/game-objects/enemies/brain/mouth-minion.js
@@ -74,7 +74,7 @@ class MouthMinion extends Enemy {
 
         // SPRITE MOVING RIGHT ( and/or UP/DOWN)
         else if (this.velocity.x >= 0 && this.direction === Direction.RIGHT) {
-            if (this.BB.right > PARAMS.CANVAS_WIDTH) {
+            if (this.BB.right > PARAMS.WIDTH) {
                 this.direction = Direction.LEFT;
             } else {
 

--- a/src/game-objects/enemies/brain/nose-minion.js
+++ b/src/game-objects/enemies/brain/nose-minion.js
@@ -64,7 +64,7 @@ class NoseMinion extends Enemy {
 
         // SPRITE MOVING RIGHT ( and/or UP/DOWN)
         else if (this.velocity.x >= 0 && this.direction === Direction.RIGHT) {
-            if (this.BB.right > PARAMS.CANVAS_WIDTH) {
+            if (this.BB.right > PARAMS.WIDTH) {
                 this.direction = Direction.LEFT;
             } else {
 

--- a/src/game-objects/enemies/cthulhu/cthulhu-arrow.js
+++ b/src/game-objects/enemies/cthulhu/cthulhu-arrow.js
@@ -44,7 +44,7 @@ class CthulhuArrow extends Enemy {
 
         this.velocity.y += this.moveFunction(VELOCITY.REGULAR, Movement.DOWN);
 
-        if (this.BB.bottom > PARAMS.CANVAS_HEIGHT - startLaser) {
+        if (this.BB.bottom > PARAMS.HEIGHT - startLaser) {
             this.velocity.y += this.moveFunction(VELOCITY.SUPERFAST, Movement.DOWN);
             this.animationType = 1;
         }
@@ -53,11 +53,11 @@ class CthulhuArrow extends Enemy {
         this.x += this.velocity.x * TICK * this.scale;
         this.y += this.velocity.y * TICK * this.scale;
 
-        if (this.BB.bottom > PARAMS.CANVAS_HEIGHT - startLaser) {
+        if (this.BB.bottom > PARAMS.HEIGHT - startLaser) {
             this.bulletPattern();
         }
 
-        if (this.y >= PARAMS.CANVAS_HEIGHT) {
+        if (this.y >= PARAMS.HEIGHT) {
             this.removeFromWorld = true;
         }
     };

--- a/src/game-objects/enemies/cthulhu/cthulhu-crab.js
+++ b/src/game-objects/enemies/cthulhu/cthulhu-crab.js
@@ -51,7 +51,7 @@ class CthulhuCrab extends Enemy {
                 this.velocity.y += amplitude * this.moveFunction(angularFrequency * (this.moveTimer++), Movement.COS);
             }
         } else if (this.velocity.x >= 0 && this.direction === Direction.RIGHT) { // SPRITE MOVING RIGHT
-            if (this.BB.right > PARAMS.CANVAS_WIDTH) {
+            if (this.BB.right > PARAMS.WIDTH) {
                 this.direction = Direction.LEFT;
             } else {
                 this.velocity.x += this.moveFunction(VELOCITY.SUPERSLOW, Movement.RIGHT);

--- a/src/game-objects/enemies/cthulhu/cthulhu-minion.js
+++ b/src/game-objects/enemies/cthulhu/cthulhu-minion.js
@@ -70,7 +70,7 @@ class CthulhuMinion extends Enemy {
 
         // SPRITE MOVING RIGHT ( and/or UP/DOWN)
         else if (this.velocity.x >= 0 && this.direction === Direction.RIGHT) {
-            if (this.x + this.BB.radius > PARAMS.CANVAS_WIDTH) { // check if we have gone off the right side of canvas
+            if (this.x + this.BB.radius > PARAMS.WIDTH) { // check if we have gone off the right side of canvas
                 this.direction = Direction.LEFT; // go left
             } else { // We know we are going right.
 

--- a/src/game-objects/enemies/cthulhu/cthulhu-squid.js
+++ b/src/game-objects/enemies/cthulhu/cthulhu-squid.js
@@ -54,7 +54,7 @@ class CthulhuSquid extends Enemy {
                 this.velocity.y += amplitude * this.moveFunction(angularFrequency * (this.moveTimer++), Movement.COS);
             }
         } else if (this.velocity.x >= 0 && this.direction === Direction.RIGHT) { // SPRITE MOVING RIGHT
-            if (this.x + this.BB.radius > PARAMS.CANVAS_WIDTH) {
+            if (this.x + this.BB.radius > PARAMS.WIDTH) {
                 this.direction = Direction.LEFT;
             } else {
                 this.velocity.x += this.moveFunction(VELOCITY.REGULAR, Movement.RIGHT);

--- a/src/game-objects/enemies/cthulhu/cthulhu.js
+++ b/src/game-objects/enemies/cthulhu/cthulhu.js
@@ -78,7 +78,7 @@ class Cthulhu extends Enemy {
         }
 
         // Randomize x-coordinate for minion.
-        this.xMinionPosition = Math.floor((Math.random() * PARAMS.CANVAS_WIDTH - 96) + 96);
+        this.xMinionPosition = Math.floor((Math.random() * PARAMS.WIDTH - 96) + 96);
 
         this.spawnTrainCreature(100, 2);
 

--- a/src/levels/cave-level.js
+++ b/src/levels/cave-level.js
@@ -1,9 +1,8 @@
-
 class CaveLevel extends Level {
     constructor(game) {
         super(game);
 
-        this.createLevel();
+        this.createLevel()
     }
 
     createLevel() {

--- a/src/loadFiles.js
+++ b/src/loadFiles.js
@@ -1,20 +1,27 @@
+async function load() {
+    let fileSystem = {
+        "engine/" : ["gameengine.js", "assetmanager.js", "animator.js", "timer.js"],
+        "game-objects/" : ["boundingbox.js", "boundingcircle.js", "bullet.js", "player.js", "powerups.js", "bulletPatterns.js"],
+        "game-objects/misc/" : ["background.js", "particles.js"],
+        "game-objects/enemies/" : ["enemy.js"],
+        "game-objects/enemies/brain/" : ["brain.js", "eye-minion.js", "mouth-minion.js", "nose-minion.js"],
+        "game-objects/enemies/cthulhu/" : ["cthulhu.js", "cthulhu-minion.js", "cthulhu-arrow.js", "cthulhu-squid.js", "cthulhu-crab.js"],
+        "game-objects/enemies/misc/" : ["fingergun.js"],
+        "levels/" : ["level.js", "cave-level.js"],
+        "" : ["util.js", "main.js"],
+    }
 
-let fileSystem = {
-    "engine/" : ["gameengine.js", "assetmanager.js", "animator.js", "timer.js"],
-    "game-objects/" : ["boundingbox.js", "boundingcircle.js", "bullet.js", "player.js", "powerups.js", "bulletPatterns.js"],
-    "game-objects/misc/" : ["background.js", "particles.js"],
-    "game-objects/enemies/" : ["enemy.js"],
-    "game-objects/enemies/brain/" : ["brain.js", "eye-minion.js", "mouth-minion.js", "nose-minion.js"],
-    "game-objects/enemies/cthulhu/" : ["cthulhu.js", "cthulhu-minion.js", "cthulhu-arrow.js", "cthulhu-squid.js", "cthulhu-crab.js"],
-    "game-objects/enemies/misc/" : ["fingergun.js"],
-    "levels/" : ["level.js", "cave-level.js"],
-    "" : ["util.js", "main.js"],
-}
-
-for (path in fileSystem) {
-    for (let i=0; i<fileSystem[path].length; i++) {
-        let script = document.createElement('script');
-        script.src = "./src/" + path + fileSystem[path][i];
-        document.head.appendChild(script);
+    for (let path in fileSystem) {
+        for (let i=0; i<fileSystem[path].length; i++) {
+            let script = document.createElement('script');
+            script.src = "./src/" + path + fileSystem[path][i];
+            document.head.appendChild(script);
+            await new Promise(r => setTimeout(r, 2));
+            script.src === "enemy.js"
+                ? await new Promise(r => setTimeout(r, 20))
+                : await new Promise(r => setTimeout(r, 2));
+        }
     }
 }
+
+load();

--- a/src/main.js
+++ b/src/main.js
@@ -1,6 +1,6 @@
-var gameEngine = new GameEngine();
+const gameEngine = new GameEngine();
+const ASSET_MANAGER = new AssetManager();
 
-var ASSET_MANAGER = new AssetManager();
 
 // Load assets here
 // Might need a separate load manager here
@@ -10,8 +10,8 @@ function loadSprites() {
 	let sprites = {
 		"" : ["player", "altPlayer", "cavebg", "explosion"],
 		"powerups/" : ["ap1_pu", "ap2_pu", "fire_rate_pu", "health_pu", "power_pu", "shield_pu"],
-		"enemies/" : ["finger_gun_dude", "cth_minion_float", "cth_minion_attack", "brain", "cthulhuSprite", 
-					  "eye", "mouth", "nose", "cthulhuSquid", "cthulhuTriangle", "cthulhuCrab"],
+		"enemies/" : ["finger_gun_dude", "cth_minion_float", "cth_minion_attack", "brain", "cthulhuSprite",
+			"eye", "mouth", "nose", "cthulhuSquid", "cthulhuTriangle", "cthulhuCrab"],
 	}
 
 	for (path in sprites) {
@@ -24,13 +24,11 @@ function loadSprites() {
 loadSprites();
 
 ASSET_MANAGER.downloadAll(function () {
-	var canvas = document.getElementById('gameWorld');
-	var ctx = canvas.getContext('2d');
+	const canvas = document.getElementById('gameWorld');
+	const ctx = canvas.getContext('2d');
 	ctx.imageSmoothingEnabled = false;
 
 	// Get canvas width & height
-	PARAMS.CANVAS_WIDTH = canvas.width;
-	PARAMS.CANVAS_HEIGHT = canvas.height;
 
 	// Focuses the canvas automatically so the user
 	// does not need to click on the screen.
@@ -40,7 +38,10 @@ ASSET_MANAGER.downloadAll(function () {
 
 	// This is where we will add the scene manager to handle
 	// the adding and removing of entities
-	gameEngine.setLevel(new CaveLevel(gameEngine));
 
+	gameEngine.setLevel(new CaveLevel(gameEngine));
 	gameEngine.start();
 });
+
+
+


### PR DESCRIPTION
Loading bug is weird because JavaScript is supposed to be synchronous in it's loading of scripts. 

I think what is happening is that it "starts" loading a script and then moves on to start the loading of the next script before it finishes loading the previous script (so technically it's still synchronous in its execution).

E.g. Even though Enemy.js starts its loading process before the Brain.js, since Brain extends Enemy and Enemy.js hasn't finished loading its entire class before Brain.js starts, it fails. 

Simple fix - During loading, I put everything to sleep for 2ms. I gave enemy 20ms to finish it's loading (longer than others because the inheritance seems to be where the issue occurs most).

If things still fail then we could increase the sleep timer for the problematic classes. If that fails then we will have to wrap everything in try/catch blocks. 